### PR TITLE
[Main]: #34 온보딩 - 국가 조회하기 api

### DIFF
--- a/Main/src/main/java/com/kusitms29/backendH/domain/sync/domain/Language.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/sync/domain/Language.java
@@ -1,7 +1,12 @@
 package com.kusitms29.backendH.domain.sync.domain;
 
+import com.kusitms29.backendH.global.error.exception.InvalidValueException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+import static com.kusitms29.backendH.global.error.ErrorCode.INVALID_LANGUAGE_TYPE;
 
 @RequiredArgsConstructor
 @Getter
@@ -9,5 +14,13 @@ public enum Language {
     KOREAN("korean"),
     ENGLISH("english");
 
-    private final String language;
+    private final String stringLanguage;
+
+    public static Language getEnumLanguageFromStringLanguage(String stringLanguage) {
+        return Arrays.stream(values())
+                .filter(language -> language.stringLanguage.equals(stringLanguage))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(INVALID_LANGUAGE_TYPE));
+    }
+
 }

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/UserController.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/UserController.java
@@ -1,19 +1,24 @@
 package com.kusitms29.backendH.domain.user.application.controller;
 
 
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.CountryCalloutRequestDto;
 import com.kusitms29.backendH.domain.user.application.controller.dto.request.UserSignInRequestDto;
 import com.kusitms29.backendH.domain.user.application.controller.dto.response.UserAuthResponseDto;
 import com.kusitms29.backendH.domain.user.application.service.AuthService;
+import com.kusitms29.backendH.domain.user.application.service.CountryDataService;
 import com.kusitms29.backendH.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
 @RestController
 public class UserController {
     private final AuthService authService;
+    private final CountryDataService countryDataService;
 
     @PostMapping("/signin")
     public ResponseEntity<SuccessResponse<?>> signIn(@RequestHeader("Authorization") final String authToken,
@@ -21,6 +26,11 @@ public class UserController {
                                                      @RequestBody final UserSignInRequestDto requestDto) {
         final UserAuthResponseDto responseDto = authService.signIn(requestDto, authToken, fcmToken);
         return SuccessResponse.ok(responseDto);
+    }
+    @GetMapping("/countries")
+    public ResponseEntity<SuccessResponse<?>> getCountries(@RequestBody CountryCalloutRequestDto requestDto) {
+        List<String> countryNames = countryDataService.listOfCountries(requestDto.getPage(), requestDto.getPerPage(), requestDto.getLanguage());
+        return SuccessResponse.ok(countryNames);
     }
 
 }

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/CountryCalloutRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/CountryCalloutRequestDto.java
@@ -1,0 +1,16 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+public class CountryCalloutRequestDto {
+    private Integer page;
+    private Integer perPage;
+    private String language;
+}
+

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/CountryDataDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/CountryDataDto.java
@@ -1,0 +1,17 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CountryDataDto {
+    private String ISO_alpha2;
+    private String ISO_alpha3;
+    private Integer ISO_numeric;
+    private String 대륙명_공통_대륙코드;
+    private String 대륙명_행정표준코드;
+    private String 대륙명_외교부_직제;
+    private String 영문명;
+    private String 한글명;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/CountryResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/CountryResponseDto.java
@@ -1,0 +1,17 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class CountryResponseDto {
+    private Integer currentCount;
+    private List<CountryDataDto> data;
+    private Integer matchCount;
+    private Integer page;
+    private Integer perPage;
+    private Integer totalCount;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/CountryDataService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/CountryDataService.java
@@ -1,0 +1,60 @@
+package com.kusitms29.backendH.domain.user.application.service;
+
+import com.kusitms29.backendH.domain.sync.domain.Language;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.CountryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class CountryDataService {
+    @Value("${openData.url}")
+    private String apiUrl;
+    @Value("${openData.authorization}")
+    private String authorization;
+
+    private final RestTemplate restTemplate;
+    public List<String> listOfCountries(Integer page, Integer perPage, String language) {
+        Language lan = Language.getEnumLanguageFromStringLanguage(language);
+        CountryResponseDto countryResponseDto = calloutCountryAPI(page, perPage);
+        return countryResponseDto.getData().stream()
+                .map(data -> lan.getStringLanguage().equals("korean") ? data.get한글명() : data.get영문명())
+                .toList();
+    }
+    private CountryResponseDto calloutCountryAPI(Integer page, Integer perPage) {
+        StringBuilder authSB = new StringBuilder();
+        authSB.append("Infuser "); authSB.append(authorization);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", authSB.toString());
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(headers);
+
+        URI apiUrlWithQuery = UriComponentsBuilder.fromHttpUrl(apiUrl)
+                .queryParam("page", page)
+                .queryParam("perPage", perPage)
+                .build()
+                .toUri();
+
+        ResponseEntity<CountryResponseDto> countryResponse = restTemplate.exchange(
+                apiUrlWithQuery, HttpMethod.GET, requestEntity, CountryResponseDto.class
+        );
+        return countryResponse.getBody();
+    }
+
+}

--- a/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
+++ b/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 플랫폼입니다"),
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일입니다."),
     INVALID_SYNC_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 싱크타입입니다."),
+    INVALID_LANGUAGE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 언어타입입니다."),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용 : 공공 데이터 국가코드 API를 RestTemplate으로 호출했습니다.

- 영어
![image](https://github.com/Kusitms-29th-MeetUp-H/Back/assets/97500298/19496578-fc4f-46e8-ac7a-d60c842dc6d8)
- 한국어
![image](https://github.com/Kusitms-29th-MeetUp-H/Back/assets/97500298/7181c2ec-fd58-4046-a6bf-d195d23c7179)

### 🎸 기타 사항 or 추가 코멘트
- 최대 196개의 국가이름을 영문명, 한글명으로 가져올 수 있습니다.
- application.yml 변경됐습니다 !