### PR TITLE
[Main]: #34 이메일 인증 API 구현

### DIFF
--- a/Main/build.gradle
+++ b/Main/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
 	//fcm
 	implementation 'com.google.firebase:firebase-admin:8.1.0'
+
+	// Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/UserController.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/UserController.java
@@ -2,10 +2,14 @@ package com.kusitms29.backendH.domain.user.application.controller;
 
 
 import com.kusitms29.backendH.domain.user.application.controller.dto.request.CountryCalloutRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.EmailVerificationRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.ReceiverInfoRequestDto;
 import com.kusitms29.backendH.domain.user.application.controller.dto.request.UserSignInRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.EmailVerificationResponseDto;
 import com.kusitms29.backendH.domain.user.application.controller.dto.response.UserAuthResponseDto;
 import com.kusitms29.backendH.domain.user.application.service.AuthService;
 import com.kusitms29.backendH.domain.user.application.service.CountryDataService;
+import com.kusitms29.backendH.domain.user.application.service.EmailVerificationService;
 import com.kusitms29.backendH.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +23,7 @@ import java.util.List;
 public class UserController {
     private final AuthService authService;
     private final CountryDataService countryDataService;
+    private final EmailVerificationService emailVerificationService;
 
     @PostMapping("/signin")
     public ResponseEntity<SuccessResponse<?>> signIn(@RequestHeader("Authorization") final String authToken,
@@ -31,6 +36,16 @@ public class UserController {
     public ResponseEntity<SuccessResponse<?>> getCountries(@RequestBody CountryCalloutRequestDto requestDto) {
         List<String> countryNames = countryDataService.listOfCountries(requestDto.getPage(), requestDto.getPerPage(), requestDto.getLanguage());
         return SuccessResponse.ok(countryNames);
+    }
+    @PostMapping("/emails/verification-requests")
+    public ResponseEntity<SuccessResponse<?>> sendMessage(@RequestBody ReceiverInfoRequestDto requestDto) {
+        emailVerificationService.sendCodeToEmail(requestDto.getToEmail());
+        return SuccessResponse.ok(true);
+    }
+    @GetMapping ("/emails/verifications")
+    ResponseEntity<SuccessResponse<?>> verificationEmail(@RequestBody EmailVerificationRequestDto requestDto) {
+        EmailVerificationResponseDto response = emailVerificationService.verifiedCode(requestDto.getEmail(), requestDto.getCode());
+        return SuccessResponse.ok(response);
     }
 
 }

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/EmailVerificationRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/EmailVerificationRequestDto.java
@@ -1,0 +1,12 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class EmailVerificationRequestDto {
+    private String email;
+    private String code;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/ReceiverInfoRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/ReceiverInfoRequestDto.java
@@ -1,0 +1,11 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReceiverInfoRequestDto {
+    private String toEmail;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/EmailVerificationResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/EmailVerificationResponseDto.java
@@ -1,0 +1,17 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class EmailVerificationResponseDto {
+
+    private boolean authResult;
+
+    public static EmailVerificationResponseDto of(Boolean authResult) {
+        return EmailVerificationResponseDto.builder()
+                .authResult(authResult)
+                .build();
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/EmailService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/EmailService.java
@@ -1,0 +1,29 @@
+package com.kusitms29.backendH.domain.user.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender javaMailSender;
+
+    public void sendEmail(String toEmail, String title, String text) {
+        SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+        javaMailSender.send(emailForm);
+    }
+
+    public SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+        return message;
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/EmailVerificationService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/EmailVerificationService.java
@@ -1,0 +1,68 @@
+package com.kusitms29.backendH.domain.user.application.service;
+
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.EmailVerificationResponseDto;
+import com.kusitms29.backendH.domain.user.domain.User;
+import com.kusitms29.backendH.domain.user.repository.UserRepository;
+import com.kusitms29.backendH.global.error.exception.ConflictException;
+import com.kusitms29.backendH.global.error.exception.InvalidValueException;
+import com.kusitms29.backendH.infra.config.RedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.Random;
+
+import static com.kusitms29.backendH.global.error.ErrorCode.DUPLICATE_USER;
+import static com.kusitms29.backendH.global.error.ErrorCode.INVALID_AUTH_CODE;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailVerificationService {
+    private static final String AUTH_CODE_PREFIX = "AuthCode ";
+    private final UserRepository userRepository;
+    private final RedisService redisService;
+
+    @Value("${mail.auth-code-expiration-millis}")
+    private String authCodeExpirationMills;
+    private final EmailService emailService;
+
+    public void sendCodeToEmail(String toEmail) {
+        this.checkDuplicatedEmail(toEmail);
+        String title = "Sync 이메일 인증 번호";
+        String authCode = this.createCode();
+        emailService.sendEmail(toEmail, title, authCode);
+        redisService.setValuesWithTimeout(AUTH_CODE_PREFIX + toEmail, authCode, Long.parseLong(this.authCodeExpirationMills));
+    }
+
+    private void checkDuplicatedEmail(String email) {
+        Optional<User> user = userRepository.findByEmail(email);
+        if(user.isPresent()) {
+            throw new ConflictException(DUPLICATE_USER);
+        }
+    }
+    private String createCode() {
+        Random rand = new Random();
+        StringBuffer authCodeSB = new StringBuffer();
+        for(int i=0; i<9; i++) {
+            authCodeSB.append((char)(rand.nextInt(26) + 65));
+        }
+        return authCodeSB.toString();
+    }
+
+    public EmailVerificationResponseDto verifiedCode(String email, String authCode) {
+        this.checkDuplicatedEmail(email);
+        String redisAuthCode = redisService.getValues(AUTH_CODE_PREFIX + email);
+        boolean authResult = redisAuthCode != null && redisAuthCode.equals(authCode);
+        if(!authResult) {
+            throw new InvalidValueException(INVALID_AUTH_CODE);
+        }
+        return EmailVerificationResponseDto.of(true);
+    }
+
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/repository/UserRepository.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPlatformId(String platformId);
+    Optional<User> findByEmail(String email);
 }

--- a/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
+++ b/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일입니다."),
     INVALID_SYNC_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 싱크타입입니다."),
     INVALID_LANGUAGE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 언어타입입니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증을 실패했습니다."),
 
     /**
      * 401 Unauthorized
@@ -66,7 +67,8 @@ public enum ErrorCode {
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     JSON_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Json 으로 변환할 수 없는 String 입니다."),
-    S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.");
+    S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    MAIL_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/Main/src/main/java/com/kusitms29/backendH/infra/config/EmailConfig.java
+++ b/Main/src/main/java/com/kusitms29/backendH/infra/config/EmailConfig.java
@@ -1,0 +1,68 @@
+package com.kusitms29.backendH.infra.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${mail.host}")
+    private String host;
+
+    @Value("${mail.port}")
+    private int port;
+
+    @Value("${mail.username}")
+    private String username;
+
+    @Value("${mail.password}")
+    private String password;
+
+    @Value("${mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+
+}

--- a/Main/src/main/java/com/kusitms29/backendH/infra/config/RedisService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/infra/config/RedisService.java
@@ -1,0 +1,28 @@
+package com.kusitms29.backendH.infra.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+    public void setValues(String key, String value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+    @Transactional
+    public void setValuesWithTimeout(String key, String value, long timeout) { // 만료 시간을 설정해서 자동 삭제 가능
+        redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MILLISECONDS);
+    }
+    public String getValues(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
- 이메일 전송 API : 수신자 이메일을 넣으면, 해당 이메일(naver, google)의 메일함에 메일이 저장됩니다. 
- 인증 코드 유효 여부 확인 API : 유효기간이 있는 인증 코드를 Redis에 저장했습니다.


### 🎸 기타 사항 or 추가 코멘트
- 이메일이 학교 이메일인지의 여부는 추후 반영하겠습니다!
- application.yml 수정했습니다.



