### PR TITLE
[Feat] Main #34 학교 이메일 인증 api 구현

### DIFF
--- a/Main/build.gradle
+++ b/Main/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven{url 'https://jitpack.io'}
 }
 
 dependencies {
@@ -51,6 +52,9 @@ dependencies {
 
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	//school email - univcert.com
+	implementation 'com.github.in-seo:univcert:master-SNAPSHOT'
 
 }
 

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/UserController.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/UserController.java
@@ -2,13 +2,12 @@ package com.kusitms29.backendH.domain.user.application.controller;
 
 
 import com.kusitms29.backendH.domain.user.application.controller.dto.request.*;
-import com.kusitms29.backendH.domain.user.application.controller.dto.response.EmailVerificationResponseDto;
-import com.kusitms29.backendH.domain.user.application.controller.dto.response.OnBoardingResponseDto;
-import com.kusitms29.backendH.domain.user.application.controller.dto.response.UserAuthResponseDto;
-import com.kusitms29.backendH.domain.user.application.service.AuthService;
-import com.kusitms29.backendH.domain.user.application.service.CountryDataService;
-import com.kusitms29.backendH.domain.user.application.service.EmailVerificationService;
-import com.kusitms29.backendH.domain.user.application.service.UserService;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail.SchoolEmailRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail.SchoolEmailVerificationRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.*;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.schoolEmail.CalloutErrorResponse;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.schoolEmail.CalloutSchoolEmailVerificationResponseDto;
+import com.kusitms29.backendH.domain.user.application.service.*;
 import com.kusitms29.backendH.global.common.SuccessResponse;
 import com.kusitms29.backendH.infra.config.auth.UserId;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +24,7 @@ public class UserController {
     private final AuthService authService;
     private final CountryDataService countryDataService;
     private final EmailVerificationService emailVerificationService;
+    private final SchoolEmailService schoolEmailService;
 
     @PostMapping("/signin")
     public ResponseEntity<SuccessResponse<?>> signIn(@RequestHeader("Authorization") final String authToken,
@@ -55,5 +55,25 @@ public class UserController {
         EmailVerificationResponseDto response = emailVerificationService.verifiedCode(requestDto.getEmail(), requestDto.getCode());
         return SuccessResponse.ok(response);
     }
+
+    @PostMapping("/school-emails/verification-requests")
+    public ResponseEntity<SuccessResponse<?>> sendMessageToSchool(@RequestBody SchoolEmailRequestDto requestDto) {
+        CalloutErrorResponse responseDto = schoolEmailService.callOutSendSchoolEmail(requestDto);
+        return SuccessResponse.ok(responseDto.isSuccess());
+    }
+
+    @PostMapping("/school-emails/verifications")
+    public ResponseEntity<SuccessResponse<?>> verificationSchoolEmail(@RequestBody SchoolEmailVerificationRequestDto requestDto) {
+        CalloutSchoolEmailVerificationResponseDto responseDto = schoolEmailService.callOutAuthSchoolEmail(requestDto);
+        return SuccessResponse.ok(responseDto);
+    }
+
+    @PostMapping("/school-emails/reset")
+    public ResponseEntity<SuccessResponse<?>> resetForTryEmailTest() {
+        CalloutErrorResponse responseDto = schoolEmailService.clearAuthCode();
+        return SuccessResponse.ok(responseDto.isSuccess());
+    }
+
+
 
 }

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/CalloutSchoolEmailRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/CalloutSchoolEmailRequestDto.java
@@ -1,0 +1,14 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+public class CalloutSchoolEmailRequestDto {
+    private String key;
+    private String email;
+    private String univName;
+    private Boolean univ_check;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/CalloutSchoolEmailVerificationRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/CalloutSchoolEmailVerificationRequestDto.java
@@ -1,0 +1,14 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+public class CalloutSchoolEmailVerificationRequestDto {
+    private String key;
+    private String email;
+    private String univName;
+    private int code;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/SchoolEmailRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/SchoolEmailRequestDto.java
@@ -1,0 +1,12 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SchoolEmailRequestDto {
+    private String email;
+    private String univName;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/SchoolEmailVerificationRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/request/schoolEmail/SchoolEmailVerificationRequestDto.java
@@ -1,0 +1,13 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SchoolEmailVerificationRequestDto {
+    private String univName;
+    private String email;
+    private int code;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/schoolEmail/CalloutErrorResponse.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/schoolEmail/CalloutErrorResponse.java
@@ -1,0 +1,12 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.response.schoolEmail;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CalloutErrorResponse {
+    private String status;
+    private boolean success;
+    private String message;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/schoolEmail/CalloutSchoolEmailVerificationResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/controller/dto/response/schoolEmail/CalloutSchoolEmailVerificationResponseDto.java
@@ -1,0 +1,13 @@
+package com.kusitms29.backendH.domain.user.application.controller.dto.response.schoolEmail;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CalloutSchoolEmailVerificationResponseDto {
+    private boolean success;
+    private String univName;
+    private String certified_email;
+    private String certified_date;
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/SchoolEmailService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/user/application/service/SchoolEmailService.java
@@ -1,0 +1,100 @@
+package com.kusitms29.backendH.domain.user.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail.CalloutSchoolEmailRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail.CalloutSchoolEmailVerificationRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail.SchoolEmailRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.request.schoolEmail.SchoolEmailVerificationRequestDto;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.schoolEmail.CalloutErrorResponse;
+import com.kusitms29.backendH.domain.user.application.controller.dto.response.schoolEmail.CalloutSchoolEmailVerificationResponseDto;
+import com.kusitms29.backendH.global.error.exception.InvalidValueException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.kusitms29.backendH.global.error.ErrorCode.*;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SchoolEmailService {
+    @Value("${unvicert.endpoint}")
+    private String apiUrl;
+
+    @Value("${unvicert.key}")
+    private String key;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public CalloutErrorResponse callOutSendSchoolEmail(SchoolEmailRequestDto requestDto) {
+        CalloutSchoolEmailRequestDto calloutSchoolEmailRequestDto = new CalloutSchoolEmailRequestDto(
+                key, requestDto.getEmail(), requestDto.getUnivName(), true
+        );
+        HttpEntity<CalloutSchoolEmailRequestDto> entity = new HttpEntity<>(calloutSchoolEmailRequestDto);
+        ResponseEntity<CalloutErrorResponse> response;
+        try {
+            response = restTemplate.exchange(
+                    apiUrl + "/certify", HttpMethod.POST, entity, CalloutErrorResponse.class
+            );
+            return response.getBody();
+        } catch(HttpClientErrorException.BadRequest ex) { //400 에러에 대한 에러 메세지 다양
+            String message = "";
+            try {
+                JsonNode jsonNode = objectMapper.readTree(ex.getResponseBodyAsString());
+                message = jsonNode.has("message") ? jsonNode.get("message").asText() : "Unknown error";
+            } catch (Exception e) {
+                log.info("Error parsing JSON: " + e.getMessage());
+            }
+            if(message.equals("이미 완료된 요청입니다.")) {
+                throw new InvalidValueException(DUPLICATE_SCHOOL_MAIL);
+            } else if(message.equals("대학과 일치하지 않는 메일 도메인입니다.")) {
+                throw new InvalidValueException(INVALID_UNIVERSITY_DOMAIN);
+            } else {
+                throw new InvalidValueException(UNIVERSITY_API_FAIL_ERROR);
+            }
+        }
+    }
+    public CalloutSchoolEmailVerificationResponseDto callOutAuthSchoolEmail(SchoolEmailVerificationRequestDto requestDto) {
+        CalloutSchoolEmailVerificationRequestDto calloutSchoolEmailVerificationRequestDto = new CalloutSchoolEmailVerificationRequestDto(
+                key, requestDto.getEmail(), requestDto.getUnivName(), requestDto.getCode()
+        );
+        HttpEntity<CalloutSchoolEmailVerificationRequestDto> entity =  new HttpEntity<>(calloutSchoolEmailVerificationRequestDto);
+        ResponseEntity<CalloutSchoolEmailVerificationResponseDto> response = restTemplate.exchange(
+                apiUrl + "/certifycode", HttpMethod.POST, entity, CalloutSchoolEmailVerificationResponseDto.class
+        );
+        if(!response.getBody().isSuccess()) {
+            throw new InvalidValueException(INVALID_AUTH_CODE);
+        }
+        return response.getBody();
+    }
+
+    public CalloutErrorResponse clearAuthCode() {
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("key", key);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(requestBody);
+
+        ResponseEntity<CalloutErrorResponse> response;
+        try {
+            response = restTemplate.exchange(
+                    apiUrl + "/clear", HttpMethod.POST, entity, CalloutErrorResponse.class
+            );
+            return response.getBody();
+        } catch (HttpClientErrorException.BadRequest ex) {
+            throw new InvalidValueException(UNIVERSITY_API_FAIL_ERROR);
+        }
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
+++ b/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_LANGUAGE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 언어타입입니다."),
     INVALID_PARENT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 카테고리부모타입입니다."),
     INVALID_GENDER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 성별타입입니다."),
+    INVALID_UNIVERSITY_DOMAIN(HttpStatus.BAD_REQUEST, "대학과 일치하지 않는 메일 도메인입니다."),
 
     /**
      * 401 Unauthorized
@@ -64,6 +65,7 @@ public enum ErrorCode {
     DUPLICATE_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
     DUPLICATE_TEAM(HttpStatus.CONFLICT, "이미 존재하는 팀입니다."),
     DUPLICATE_PARTICIPATION(HttpStatus.CONFLICT, "이미 참여했습니다."),
+    DUPLICATE_SCHOOL_MAIL(HttpStatus.CONFLICT, "이미 메일을 보냈습니다."),
 
 
     /**
@@ -72,7 +74,8 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     JSON_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Json 으로 변환할 수 없는 String 입니다."),
     S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
-    MAIL_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");
+    MAIL_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다."),
+    UNIVERSITY_API_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "대학 검증 API요청을 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
- 외부 라이브러리를 통해 대학교 이메일 인증 api를 RestTemplate으로 구현했습니다.
  - 인증메일발송api, 
  - 인증코드확인api, 
  - 인증리셋api (이미 메일을 받은 유저는 3번 api 없이는 해당 이메일로 재인증 불가입니다)

### 🎸 기타 사항 or 추가 코멘트
- application.yml 수정했습니다.




