### PR TITLE
[Feat] #49 Main 게시글[생활/질문] 조회 api

### DIFF
--- a/Main/src/main/java/com/kusitms29/backendH/domain/comment/repository/CommentRepository.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.kusitms29.backendH.domain.comment.repository;
+
+import com.kusitms29.backendH.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    int countByPostId(Long postId);
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/application/controller/dto/PostController.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/application/controller/dto/PostController.java
@@ -19,7 +19,7 @@ public class PostController {
     private final PostService postService;
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getPagingPostByPostType(@UserId Long userId, @RequestParam String postType, Pageable pageable) {
-        List<LifePostResponseDto> responseDto = postService.getAllLifePosts(userId, postType, pageable);
+        List<LifePostResponseDto> responseDto = postService.getPagingPostByPostType(userId, postType, pageable);
         return SuccessResponse.ok(responseDto);
     }
 

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/application/controller/dto/PostController.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/application/controller/dto/PostController.java
@@ -1,0 +1,27 @@
+package com.kusitms29.backendH.domain.post.application.controller.dto;
+
+import com.kusitms29.backendH.domain.post.application.controller.dto.response.LifePostResponseDto;
+import com.kusitms29.backendH.domain.post.application.service.PostService;
+import com.kusitms29.backendH.global.common.SuccessResponse;
+import com.kusitms29.backendH.infra.config.auth.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/post")
+@RestController
+public class PostController {
+
+    private final PostService postService;
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getPagingPostByPostType(@UserId Long userId, @RequestParam String postType, Pageable pageable) {
+        List<LifePostResponseDto> responseDto = postService.getAllLifePosts(userId, postType, pageable);
+        return SuccessResponse.ok(responseDto);
+    }
+
+
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/application/controller/dto/response/LifePostResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/application/controller/dto/response/LifePostResponseDto.java
@@ -1,0 +1,37 @@
+package com.kusitms29.backendH.domain.post.application.controller.dto.response;
+
+import com.kusitms29.backendH.domain.post.domain.PostType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class LifePostResponseDto {
+    private long postId;
+    private PostType postType;
+    private String writer;
+    private LocalDateTime createdDate;
+    private String title;
+    private String content;
+    private int likeCnt;
+    private boolean isLikedByUser;
+    private int commentCnt;
+
+    public static LifePostResponseDto of(Long postId, PostType postType, String writer,
+                                         LocalDateTime createdDate, String title, String content,
+                                         int likeCnt, boolean isLikedByUser, int commentCnt) {
+        return LifePostResponseDto.builder()
+                .postId(postId)
+                .postType(postType)
+                .writer(writer)
+                .createdDate(createdDate)
+                .title(title)
+                .content(content)
+                .likeCnt(likeCnt)
+                .isLikedByUser(isLikedByUser)
+                .commentCnt(commentCnt)
+                .build();
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/application/service/PostService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/application/service/PostService.java
@@ -1,0 +1,53 @@
+package com.kusitms29.backendH.domain.post.application.service;
+
+import com.kusitms29.backendH.domain.comment.repository.CommentRepository;
+import com.kusitms29.backendH.domain.post.application.controller.dto.response.LifePostResponseDto;
+import com.kusitms29.backendH.domain.post.domain.Post;
+import com.kusitms29.backendH.domain.post.domain.PostType;
+import com.kusitms29.backendH.domain.post.repository.PostRepository;
+import com.kusitms29.backendH.domain.postLike.repository.PostLikeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PostService {
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final CommentRepository commentRepository;
+
+    public List<LifePostResponseDto> getAllLifePosts(Long userId, String postType, Pageable pageable) {
+        PostType enumPostType = PostType.getEnumPostTypeFromStringPostType(postType);
+        Page<Post> lifePosts = postRepository.findByPostType(enumPostType, pageable);
+        return lifePosts.stream()
+                .map(post -> mapToLifePostResponseDto(post, userId))
+                .collect(Collectors.toList());
+    }
+
+    private LifePostResponseDto mapToLifePostResponseDto(Post post, Long userId) {
+        int likeCount = postLikeRepository.countByPostId(post.getId());
+        boolean isLikedByUser = postLikeRepository.existsByPostIdAndUserId(post.getId(), userId);
+        int commentCount = commentRepository.countByPostId(post.getId());
+
+        return LifePostResponseDto.of(
+                post.getId(),
+                post.getPostType(),
+                post.getUser().getUserName(),
+                post.getCreatedAt(),
+                post.getTitle(),
+                post.getContent(),
+                likeCount,
+                isLikedByUser,
+                commentCount
+        );
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/application/service/PostService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/application/service/PostService.java
@@ -25,7 +25,7 @@ public class PostService {
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
 
-    public List<LifePostResponseDto> getAllLifePosts(Long userId, String postType, Pageable pageable) {
+    public List<LifePostResponseDto> getPagingPostByPostType(Long userId, String postType, Pageable pageable) {
         PostType enumPostType = PostType.getEnumPostTypeFromStringPostType(postType);
         Page<Post> lifePosts = postRepository.findByPostType(enumPostType, pageable);
         return lifePosts.stream()

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/domain/PostType.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/domain/PostType.java
@@ -1,12 +1,24 @@
 package com.kusitms29.backendH.domain.post.domain;
 
+import com.kusitms29.backendH.global.error.ErrorCode;
+import com.kusitms29.backendH.global.error.exception.InvalidValueException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+import static com.kusitms29.backendH.global.error.ErrorCode.INVALID_POST_TYPE;
 
 @RequiredArgsConstructor
 @Getter
 public enum PostType {
     C("생활"),
     Q("질문");
-    private final String postType;
+    private final String stringPostType;
+    public static PostType getEnumPostTypeFromStringPostType(String stringPostType) {
+        return Arrays.stream(values())
+                .filter(postType -> postType.stringPostType.equals(stringPostType))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(INVALID_POST_TYPE));
+    }
 }

--- a/Main/src/main/java/com/kusitms29/backendH/domain/post/repository/PostRepository.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/post/repository/PostRepository.java
@@ -1,0 +1,14 @@
+package com.kusitms29.backendH.domain.post.repository;
+
+import com.kusitms29.backendH.domain.post.domain.Post;
+import com.kusitms29.backendH.domain.post.domain.PostType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends PagingAndSortingRepository<Post, Long> {
+    Page<Post> findByPostType(PostType postType, Pageable pageable);
+}
+

--- a/Main/src/main/java/com/kusitms29/backendH/domain/postLike/domain/PostLike.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/postLike/domain/PostLike.java
@@ -11,6 +11,7 @@ import lombok.*;
 @Builder
 @Getter
 @Table(name = "postLike")
+@Entity
 public class PostLike extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Main/src/main/java/com/kusitms29/backendH/domain/postLike/repository/PostLikeRepository.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/postLike/repository/PostLikeRepository.java
@@ -1,0 +1,12 @@
+package com.kusitms29.backendH.domain.postLike.repository;
+
+import com.kusitms29.backendH.domain.postLike.domain.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    int countByPostId(Long postId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
+}

--- a/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
+++ b/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     INVALID_GENDER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 성별타입입니다."),
     INVALID_UNIVERSITY_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 대학이름입니다."),
     INVALID_UNIVERSITY_DOMAIN(HttpStatus.BAD_REQUEST, "대학과 일치하지 않는 메일 도메인입니다."),
+    INVALID_POST_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 게시물타입입니다."),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
- 생활과 질문(PostType)에 따라 게시물 조회를 가능하게 했습니다.
- Paging 처리를 해서 기본으로 20개씩 끊어서 보냅니다.
- 각 게시물의 제목, 댓글, 좋아요, 댓글 수, 내가 누른 좋아요 인지 등의 정보를 보냅니다.
