### PR TITLE
[Main]: #65 싱크 개설 api 구현

### DIFF
--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/controller/SyncManageController.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/controller/SyncManageController.java
@@ -1,4 +1,29 @@
 package com.kusitms29.backendH.api.sync.controller;
 
+import com.kusitms29.backendH.api.sync.service.SyncService;
+import com.kusitms29.backendH.api.sync.service.dto.request.SyncCreateRequestDto;
+import com.kusitms29.backendH.api.sync.service.dto.response.SyncSaveResponseDto;
+import com.kusitms29.backendH.global.common.SuccessResponse;
+import com.kusitms29.backendH.infra.config.auth.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/sync")
+@RestController
 public class SyncManageController {
+    private final SyncService syncService;
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createSync(@UserId Long userId,
+                                                         @RequestPart MultipartFile image,
+                                                         @RequestPart SyncCreateRequestDto requestDto) {
+        SyncSaveResponseDto responseDto = syncService.createSync(userId, image, requestDto);
+        return SuccessResponse.ok(responseDto);
+    }
+
 }

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/SyncService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/SyncService.java
@@ -139,23 +139,23 @@ public class SyncService {
         String image = awsS3Service.uploadImage(file);
 
         LocalDateTime oneTimeLocalDateTime = null;
-        if(!requestDto.getDate().isEmpty()) {
+        if(requestDto.getDate() != null && !requestDto.getDate().isEmpty()) {
             oneTimeLocalDateTime= parseToLocalDateTime(requestDto.getDate()); //2023-04-13 15:30
         }
 
         String regularDay = null;
-        if(!requestDto.getRegularDay().isEmpty()) {
+        if(requestDto.getRegularDay() != null && !requestDto.getRegularDay().isEmpty()) {
             regularDay = requestDto.getRegularDay();
         }
 
         LocalDateTime regularLocalDateTime = null;
-        if(!requestDto.getRoutineDate().isEmpty()) {
+        if(requestDto.getRoutineDate() != null && !requestDto.getRoutineDate().isEmpty()) {
             regularLocalDateTime = parseToLocalDateTime(requestDto.getRoutineDate()); //2023-04-13 15:30
         }
 
         LocalTime regularLocalTime = null;
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-        if(!requestDto.getRegularTime().isEmpty()) { //15:30
+        if(requestDto.getRegularTime() != null && !requestDto.getRegularTime().isEmpty()) { //15:30
             regularLocalTime = LocalTime.parse(requestDto.getRegularTime(), formatter);
         }
 

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/SyncService.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/SyncService.java
@@ -7,6 +7,7 @@ import com.kusitms29.backendH.api.sync.service.dto.response.SyncAssociateInfoRes
 import com.kusitms29.backendH.api.sync.service.dto.response.SyncInfoResponseDto;
 import com.kusitms29.backendH.api.sync.service.dto.response.SyncSaveResponseDto;
 import com.kusitms29.backendH.domain.category.entity.Type;
+import com.kusitms29.backendH.domain.category.service.CategoryReader;
 import com.kusitms29.backendH.domain.category.service.UserCategoryManager;
 import com.kusitms29.backendH.domain.category.service.UserCategoryReader;
 import com.kusitms29.backendH.domain.sync.entity.SyncType;
@@ -144,22 +145,28 @@ public class SyncService {
         //TODO member_min / max : validation - 최소 3명 최대 30명
         //TODO detail type : 예외 처리
 
-        Sync newSync = syncAppender.save(Sync.createSync(user,
-                requestDto.getSyncIntro(),
-                enumSyncType,
-                requestDto.getSyncName(),
-                image,
-                requestDto.getLocation(),
-                oneTimeLocalDateTime,
-                regularDay,
-                regularLocalTime,
-                regularLocalDateTime,
-                requestDto.getMember_min(),
-                requestDto.getMember_max(),
-                enumType,
-                requestDto.getDetailType()));
+        Sync newSync = syncAppender.save(
+                Sync.createSync(
+                        user,
+                        requestDto.getUserIntro(),
+                        requestDto.getSyncIntro(),
+                        enumSyncType,
+                        requestDto.getSyncName(),
+                        image,
+                        requestDto.getLocation(),
+                        oneTimeLocalDateTime,
+                        regularDay,
+                        regularLocalTime,
+                        regularLocalDateTime,
+                        requestDto.getMember_min(),
+                        requestDto.getMember_max(),
+                        enumType,
+                        requestDto.getDetailType())
+        );
 
-        return SyncSaveResponseDto.of(newSync.getId(),
+        return SyncSaveResponseDto.of(
+                newSync.getId(),
+                newSync.getUserIntro(),
                 newSync.getSyncIntro(),
                 newSync.getSyncType(),
                 newSync.getSyncName(),
@@ -172,7 +179,8 @@ public class SyncService {
                 newSync.getMember_min(),
                 newSync.getMember_max(),
                 newSync.getType(),
-                newSync.getDetailType());
+                newSync.getDetailType()
+        );
     }
 
     private LocalDateTime parseToLocalDateTime(String date) {

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/request/SyncCreateRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/request/SyncCreateRequestDto.java
@@ -1,20 +1,28 @@
 package com.kusitms29.backendH.api.sync.service.dto.request;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class SyncCreateRequestDto {
+    private String syncIntro;
     private String syncType;
-    private String parentCategory;
-    private String childCategory;
-    private String name;
-    private String comment;
+    private String syncName;
     private String location;
-    private String date;
-    private int meeting_cnt;
+    private String date; //일회성, 내친소
+
+    private String regularDay; //지속성
+    private String regularTime; //지속성
+    private String routineDate; //지속성
+
     private int member_min;
+
     private int member_max;
+
+    private String type; //언어교환, 엔터테인먼트, ...
+
+    private String detailType;
 }

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/request/SyncCreateRequestDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/request/SyncCreateRequestDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class SyncCreateRequestDto {
+    private String userIntro;
     private String syncIntro;
     private String syncType;
     private String syncName;

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/response/SyncSaveResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/response/SyncSaveResponseDto.java
@@ -28,7 +28,7 @@ public class SyncSaveResponseDto {
 
     private int member_max;
 
-    private String type; //언어교환, 엔터테인먼트, ...
+    private String type; //외국어, 엔터테인먼트, ...
 
     private String detailType;
 

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/response/SyncSaveResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/response/SyncSaveResponseDto.java
@@ -1,0 +1,60 @@
+package com.kusitms29.backendH.api.sync.service.dto.response;
+
+import com.kusitms29.backendH.domain.category.entity.Type;
+import com.kusitms29.backendH.domain.sync.entity.SyncType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class SyncSaveResponseDto {
+    private long syncId;
+    private String link;
+    private String syncIntro;
+    private String syncType;
+    private String syncName;
+    private String image;
+    private String location;
+    private LocalDateTime date; //일회성, 내친소
+
+    private String regularDay; //지속성 요일
+    private LocalTime regularTime; //지속성 시간
+    private LocalDateTime routineDate; //지속성 첫모임
+
+    private int member_min;
+
+    private int member_max;
+
+    private String type; //언어교환, 엔터테인먼트, ...
+
+    private String detailType;
+
+
+    public static SyncSaveResponseDto of(Long syncId, String syncIntro,
+                                         SyncType syncType, String syncName,
+                                         String image, String location,
+                                         LocalDateTime date,
+                                         String regularDay, LocalTime regularTime, LocalDateTime routineDate,
+                                         int member_min, int member_max,
+                                         Type type, String detailType) {
+        return SyncSaveResponseDto.builder()
+                .syncId(syncId)
+                .syncIntro(syncIntro)
+                .syncType(syncType.getStringSyncType())
+                .syncName(syncName)
+                .image(image)
+                .location(location)
+                .date(date)
+                .regularDay(regularDay)
+                .regularTime(regularTime)
+                .routineDate(routineDate)
+                .member_min(member_min)
+                .member_max(member_max)
+                .type(type.getStringType())
+                .detailType(detailType)
+                .build();
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/response/SyncSaveResponseDto.java
+++ b/Main/src/main/java/com/kusitms29/backendH/api/sync/service/dto/response/SyncSaveResponseDto.java
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 @Getter
 public class SyncSaveResponseDto {
     private long syncId;
-    private String link;
+    private String userIntro;
     private String syncIntro;
     private String syncType;
     private String syncName;
@@ -33,7 +33,7 @@ public class SyncSaveResponseDto {
     private String detailType;
 
 
-    public static SyncSaveResponseDto of(Long syncId, String syncIntro,
+    public static SyncSaveResponseDto of(Long syncId, String userIntro, String syncIntro,
                                          SyncType syncType, String syncName,
                                          String image, String location,
                                          LocalDateTime date,
@@ -42,6 +42,7 @@ public class SyncSaveResponseDto {
                                          Type type, String detailType) {
         return SyncSaveResponseDto.builder()
                 .syncId(syncId)
+                .userIntro(userIntro)
                 .syncIntro(syncIntro)
                 .syncType(syncType.getStringSyncType())
                 .syncName(syncName)

--- a/Main/src/main/java/com/kusitms29/backendH/domain/sync/entity/Sync.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/sync/entity/Sync.java
@@ -68,13 +68,14 @@ public class Sync extends BaseEntity {
         return new Sync(syncId,null,null,null,null,null,null,null,null,null,null,null,null,null,0,0,null,null,null,null);
     }
 
-    public static Sync createSync(User user, String syncIntro, SyncType syncType,
+    public static Sync createSync(User user, String userIntro, String syncIntro, SyncType syncType,
                                   String syncName, String image, String location, LocalDateTime date,
                                   String regularDay, LocalTime regularTime, LocalDateTime routineDate,
                                   int member_min, int member_max,
                                   Type type, String detailType){
         return Sync.builder()
                 .user(user)
+                .userIntro(userIntro)
                 .syncIntro(syncIntro)
                 .syncType(syncType)
                 .syncName(syncName)

--- a/Main/src/main/java/com/kusitms29/backendH/domain/sync/entity/Sync.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/sync/entity/Sync.java
@@ -64,20 +64,26 @@ public class Sync extends BaseEntity {
         RECRUITING, COMPLETED, DELETED;
     }
 
-    public static Sync createSync(User user, String link, SyncType syncType,
-                                   String name, String image, String content, String location,
-                                   LocalDateTime localDateTime, int member_min, int member_max) {
+    public static Sync createSync(User user, String syncIntro, SyncType syncType,
+                                  String syncName, String image, String location, LocalDateTime date,
+                                  String regularDay, LocalTime regularTime, LocalDateTime routineDate,
+                                  int member_min, int member_max,
+                                  Type type, String detailType){
         return Sync.builder()
                 .user(user)
-                .link(link)
+                .syncIntro(syncIntro)
                 .syncType(syncType)
-                .syncName(name)
+                .syncName(syncName)
                 .image(image)
-                .content(content)
                 .location(location)
-                .date(localDateTime)
+                .date(date)
+                .regularDay(regularDay)
+                .regularTime(regularTime)
+                .routineDate(routineDate)
                 .member_min(member_min)
                 .member_max(member_max)
+                .type(type)
+                .detailType(detailType)
                 .build();
     }
 

--- a/Main/src/main/java/com/kusitms29/backendH/domain/sync/service/SyncAppender.java
+++ b/Main/src/main/java/com/kusitms29/backendH/domain/sync/service/SyncAppender.java
@@ -1,0 +1,15 @@
+package com.kusitms29.backendH.domain.sync.service;
+
+import com.kusitms29.backendH.domain.sync.entity.Sync;
+import com.kusitms29.backendH.domain.sync.repository.SyncRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SyncAppender {
+    private final SyncRepository syncRepository;
+    public Sync save(Sync sync) {
+        return syncRepository.save(sync);
+    }
+}

--- a/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
+++ b/Main/src/main/java/com/kusitms29/backendH/global/error/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
     INVALID_UNIVERSITY_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 대학이름입니다."),
     INVALID_UNIVERSITY_DOMAIN(HttpStatus.BAD_REQUEST, "대학과 일치하지 않는 메일 도메인입니다."),
     INVALID_POST_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 게시물타입입니다."),
+    INVALID_PARENT_CHILD_CATEGORY(HttpStatus.BAD_REQUEST, "부모 카테고리가 불일치합니다."),
+
 
     /**
      * 401 Unauthorized
@@ -68,6 +70,11 @@ public enum ErrorCode {
     TOO_LONG_CONTENT_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "내용은 300자까지만 작성할 수 있어요"),
     TOO_LONG_COMMENT_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "댓글은 30자까지만 작성할 수 있어요"),
     TOO_MANY_IMAGES_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "이미지는 최대 5개까지 입니다."),
+    SYNC_NAME_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "싱크 제목은 15자까지만 작성할 수 있어요"),
+    SYNC_INTRO_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "싱크 내용은 500자까지만 작성할 수 있어요."),
+    USER_INTRO_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "싱크장 소개는 50자까지만 작성할 수 있어요,"),
+    SYNC_MIN_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "최소인원은 3명부터입니다."),
+    SYNC_MAX_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "최대인원은 30명까지입니다."),
 
     /**
      * 409 Conflict
@@ -79,7 +86,6 @@ public enum ErrorCode {
     DUPLICATE_SCHOOL_MAIL(HttpStatus.CONFLICT, "이미 메일을 보냈습니다."),
     DUPLICATE_POST_LIKE(HttpStatus.CONFLICT, "이미 게시글을 좋아요했습니다."),
     DUPLICATE_COMMENT_LIKE(HttpStatus.CONFLICT, "이미 댓글을 좋아요했습니다."),
-
 
     /**
      * 500 Internal Server Error


### PR DESCRIPTION
### ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 싱크 개설 api를 구현했습니다.


### 🎸 기타 사항 or 추가 코멘트
- 지속성과 지속성이 아닌 타입의 경우(SyncType)로 나뉘어서 entity 내에서 쓰이는 필드들이 상이합니다
   -  싱크 개설 response에서 각각의 상황에서 사용하지 않는 필드들을 null로 반환합니다.
- 계층에 대한 정리 필요 : 아래 개발자분이 피드백 주신 내용이 해당 pr에서도 존재함! 추후 수정
```
계층에 대한 정리가 필요해보여요!

현재 Service는 아래와 같이 3가지 다른 형태의 객체들을 참조해요!
Service -> Serivce(AWSS3)
Service -> Reader/Appender
Service -> Manager
여러 계층간 참조를 하고 있으면 추후에 의존성 관리에 어려움을 겪을 수 있어요! 조금 더 간단하게 레이어를 나누고 규칙을 가져가보세요!
```
